### PR TITLE
Update README.md

### DIFF
--- a/community-reports/cobra-report/cobra-report.hbs
+++ b/community-reports/cobra-report/cobra-report.hbs
@@ -1,7 +1,9 @@
+### Summary:
 | **Tests 📝** | **Passed ✅** | **Failed ❌** | **Skipped ⏭️** |
 | --- | --- | --- | --- |
 | {{ctrf.summary.tests}} | {{ctrf.summary.passed}} | {{ctrf.summary.failed}} | {{ctrf.summary.skipped}} |
 
+### Failed Tests:
 {{#if (anyFailedTests ctrf.tests)}}
 <table>
   <thead>


### PR DESCRIPTION
Add tutorial regarding commenting on a fork pull request. Commenting on fork pull requests using pull_request_target can be insecure. Using two workflow approach works for all types of pull requests while maintaining the repository security.