### PR TITLE
docs: community typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Add the following to your workflow file:
   with:
     report-path: './ctrf/*.json'
     community-report: true
-    communty-report-name: summary-short
+    community-report-name: summary-short
   if: always()
 ```
 

--- a/community-reports/cobra-report/README.md
+++ b/community-reports/cobra-report/README.md
@@ -22,7 +22,7 @@ Then, add it to your workflow file as follows:
   with:
     report-path: './ctrf/*.json'
     community-report: true
-    communty-report-name: cobra-report
+    community-report-name: cobra-report
   if: always()
 ```
 


### PR DESCRIPTION
Discovered the typo at the end of a CI run after copy and pasting. Figure this will save some folk a few minutes.