### PR TITLE
feat: Add limits for flaky and fail rate reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ For more advanced usage, there are several inputs available.
     # Advanced Options
     artifact-name: 'ctrf-report' # Name of the artifact containing test reports. Default is ctrf-report
     previous-results-max: 10 # Maximum number of previous test results to display in the report. Default is 10
-    flaky-rate-report-max: 10 # Maximum number of flaky tests to display in the flaky rate report. Default is 10
-    fail-rate-report-max: 10 # Maximum number of failed tests to display in the fail rate report. Default is 10
+    flaky-rate-report-max: -1 # Maximum number of flaky tests to display in the flaky rate report. Default is -1 (all results)
+    fail-rate-report-max: -1 # Maximum number of failed tests to display in the fail rate report. Default is -1 (all results)
     fetch-previous-results: false # Always fetch previous workflow runs when using custom templates. Default is false
     max-workflow-runs-to-check: 400 # Maximum number of workflow runs to check for previous results. Default is 400
     max-previous-runs-to-fetch: 100 # Maximum number of previous runs to fetch and process for metrics and reports. Default is 100

--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ For more advanced usage, there are several inputs available.
     # Advanced Options
     artifact-name: 'ctrf-report' # Name of the artifact containing test reports. Default is ctrf-report
     previous-results-max: 10 # Maximum number of previous test results to display in the report. Default is 10
+    flaky-rate-report-max: 10 # Maximum number of flaky tests to display in the flaky rate report. Default is 10
+    fail-rate-report-max: 10 # Maximum number of failed tests to display in the fail rate report. Default is 10
     fetch-previous-results: false # Always fetch previous workflow runs when using custom templates. Default is false
     max-workflow-runs-to-check: 400 # Maximum number of workflow runs to check for previous results. Default is 400
     max-previous-runs-to-fetch: 100 # Maximum number of previous runs to fetch and process for metrics and reports. Default is 100

--- a/__tests__/ctrf/helpers.test.ts
+++ b/__tests__/ctrf/helpers.test.ts
@@ -1,4 +1,11 @@
-import { getEmoji, normalizeSuite, stripAnsi } from "../../src/ctrf/helpers.js";
+import {
+	getEmoji,
+	limitFailRateReport,
+	limitFlakyRateReport,
+	normalizeSuite,
+	stripAnsi,
+} from "../../src/ctrf/helpers.js";
+import type { CTRFReport } from "ctrf";
 
 describe("getEmoji", () => {
 	it('returns the correct emoji for "passed"', () => {
@@ -79,6 +86,106 @@ describe("normalizeSuite", () => {
 	it("handles empty string", () => {
 		const result = normalizeSuite("");
 		expect(result).toBeUndefined();
+	});
+});
+
+describe("limitFlakyRateReport", () => {
+	function makeReport(): CTRFReport {
+		return {
+			results: {
+				tests: [
+					{ name: "low", insights: { flakyRate: { current: 0.1 } } },
+					{ name: "high", insights: { flakyRate: { current: 0.5 } } },
+					{ name: "stable", insights: { flakyRate: { current: 0 } } },
+					{ name: "missing" },
+				],
+			},
+		} as unknown as CTRFReport;
+	}
+
+	it("limits flaky tests by descending flaky rate without changing the source report", () => {
+		const report = makeReport();
+
+		const limitedReport = limitFlakyRateReport(report, 1);
+
+		expect(limitedReport.results.tests.map((test) => test.name)).toEqual([
+			"high",
+		]);
+		expect(report.results.tests).toHaveLength(4);
+	});
+
+	it("returns the original report when the limit is zero or negative", () => {
+		const report = makeReport();
+
+		expect(limitFlakyRateReport(report, 0)).toBe(report);
+		expect(limitFlakyRateReport(report, -1)).toBe(report);
+	});
+
+	it("returns all positive flaky-rate tests when the limit exceeds the matches", () => {
+		const report = makeReport();
+
+		const limitedReport = limitFlakyRateReport(report, 10);
+
+		expect(limitedReport.results.tests.map((test) => test.name)).toEqual([
+			"high",
+			"low",
+		]);
+	});
+
+	it("returns the original report when tests are unavailable", () => {
+		const report = { results: {} } as unknown as CTRFReport;
+
+		expect(limitFlakyRateReport(report, 1)).toBe(report);
+	});
+});
+
+describe("limitFailRateReport", () => {
+	function makeReport(): CTRFReport {
+		return {
+			results: {
+				tests: [
+					{ name: "low", insights: { failRate: { current: 0.1 } } },
+					{ name: "high", insights: { failRate: { current: 0.5 } } },
+					{ name: "stable", insights: { failRate: { current: 0 } } },
+					{ name: "missing" },
+				],
+			},
+		} as unknown as CTRFReport;
+	}
+
+	it("limits failed tests by descending fail rate without changing the source report", () => {
+		const report = makeReport();
+
+		const limitedReport = limitFailRateReport(report, 1);
+
+		expect(limitedReport.results.tests.map((test) => test.name)).toEqual([
+			"high",
+		]);
+		expect(report.results.tests).toHaveLength(4);
+	});
+
+	it("returns the original report when the limit is zero or negative", () => {
+		const report = makeReport();
+
+		expect(limitFailRateReport(report, 0)).toBe(report);
+		expect(limitFailRateReport(report, -1)).toBe(report);
+	});
+
+	it("returns all positive fail-rate tests when the limit exceeds the matches", () => {
+		const report = makeReport();
+
+		const limitedReport = limitFailRateReport(report, 10);
+
+		expect(limitedReport.results.tests.map((test) => test.name)).toEqual([
+			"high",
+			"low",
+		]);
+	});
+
+	it("returns the original report when tests are unavailable", () => {
+		const report = { results: {} } as unknown as CTRFReport;
+
+		expect(limitFailRateReport(report, 1)).toBe(report);
 	});
 });
 

--- a/action.yml
+++ b/action.yml
@@ -228,6 +228,14 @@ inputs:
       Includes test results from current run'
     required: false
     default: 10
+  flaky-rate-report-max:
+    description: 'Maximum number of flaky tests to display in the flaky rate report.'
+    required: false
+    default: 10
+  fail-rate-report-max:
+    description: 'Maximum number of failed tests to display in the fail rate report.'
+    required: false
+    default: 10
   fetch-previous-results:
     description:
       'Always fetch previous workflow runs when using custom templates.'

--- a/action.yml
+++ b/action.yml
@@ -231,11 +231,11 @@ inputs:
   flaky-rate-report-max:
     description: 'Maximum number of flaky tests to display in the flaky rate report.'
     required: false
-    default: 10
+    default: -1
   fail-rate-report-max:
     description: 'Maximum number of failed tests to display in the fail rate report.'
     required: false
-    default: 10
+    default: -1
   fetch-previous-results:
     description:
       'Always fetch previous workflow runs when using custom templates.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -150008,6 +150008,36 @@ function limitPreviousReports(report, maxPreviousReports) {
   );
   return report;
 }
+function limitFlakyRateReport(report, maxFlakyTests) {
+  if (!report.results?.tests || maxFlakyTests <= 0) {
+    return report;
+  }
+  const flakyTests = report.results.tests.filter((test) => test.insights?.flakyRate?.current > 0).sort(
+    (a6, b6) => (b6.insights?.flakyRate?.current ?? 0) - (a6.insights?.flakyRate?.current ?? 0)
+  ).slice(0, maxFlakyTests);
+  return {
+    ...report,
+    results: {
+      ...report.results,
+      tests: flakyTests
+    }
+  };
+}
+function limitFailRateReport(report, maxFailedTests) {
+  if (!report.results?.tests || maxFailedTests <= 0) {
+    return report;
+  }
+  const failedTests = report.results.tests.filter((test) => test.insights?.failRate?.current > 0).sort(
+    (a6, b6) => (b6.insights?.failRate?.current ?? 0) - (a6.insights?.failRate?.current ?? 0)
+  ).slice(0, maxFailedTests);
+  return {
+    ...report,
+    results: {
+      ...report.results,
+      tests: failedTests
+    }
+  };
+}
 function getEmoji(status) {
   switch (status) {
     case "passed":
@@ -200416,7 +200446,11 @@ function generateReportByType(reportType, inputs, report) {
     case "fail-rate-report":
       if (reportConditionals?.showFailedReports) {
         info("Adding fail rate report to summary");
-        addViewToSummary("### Fail Rate", BuiltInReports.FailRateTable, report);
+        addViewToSummary(
+          "### Fail Rate",
+          BuiltInReports.FailRateTable,
+          limitFailRateReport(report, inputs.failRateReportMax)
+        );
       } else {
         info("No failed tests to display, skipping fail-rate-report");
       }
@@ -200447,7 +200481,7 @@ function generateReportByType(reportType, inputs, report) {
         addViewToSummary(
           "### Flaky Rate",
           BuiltInReports.FlakyRateTable,
-          report
+          limitFlakyRateReport(report, inputs.flakyRateReportMax)
         );
       } else {
         info("No flaky tests to display, skipping flaky-rate-report");
@@ -200646,6 +200680,14 @@ function getInputs() {
     useSuiteName: getInput("use-suite-name").toLowerCase() === "true",
     previousResultsMax: parseInt(
       getInput("previous-results-max") || "10",
+      10
+    ),
+    flakyRateReportMax: parseInt(
+      getInput("flaky-rate-report-max") || "-1",
+      10
+    ),
+    failRateReportMax: parseInt(
+      getInput("fail-rate-report-max") || "-1",
       10
     ),
     metricsReportsMax: parseInt(

--- a/dist/index.js
+++ b/dist/index.js
@@ -200447,7 +200447,7 @@ function generateReportByType(reportType, inputs, report) {
       if (reportConditionals?.showFailedReports) {
         info("Adding fail rate report to summary");
         addViewToSummary(
-          "### Fail Rate",
+          inputs.failRateReportMax > 0 ? `### Fail Rate - Top ${inputs.failRateReportMax} ` : "### Fail Rate",
           BuiltInReports.FailRateTable,
           limitFailRateReport(report, inputs.failRateReportMax)
         );
@@ -200479,7 +200479,7 @@ function generateReportByType(reportType, inputs, report) {
       if (reportConditionals?.showFlakyReports) {
         info("Adding flaky rate report to summary");
         addViewToSummary(
-          "### Flaky Rate",
+          inputs.flakyRateReportMax > 0 ? `### Flaky Rate - Top ${inputs.flakyRateReportMax} ` : "### Flaky Rate",
           BuiltInReports.FlakyRateTable,
           limitFlakyRateReport(report, inputs.flakyRateReportMax)
         );

--- a/src/core/inputs.ts
+++ b/src/core/inputs.ts
@@ -78,11 +78,11 @@ export function getInputs(): Inputs {
 			10,
 		),
 		flakyRateReportMax: parseInt(
-			core.getInput("flaky-rate-report-max") || "10",
+			core.getInput("flaky-rate-report-max") || "-1",
 			10,
 		),
 		failRateReportMax: parseInt(
-			core.getInput("fail-rate-report-max") || "10",
+			core.getInput("fail-rate-report-max") || "-1",
 			10,
 		),
 		metricsReportsMax: parseInt(

--- a/src/core/inputs.ts
+++ b/src/core/inputs.ts
@@ -77,6 +77,14 @@ export function getInputs(): Inputs {
 			core.getInput("previous-results-max") || "10",
 			10,
 		),
+		flakyRateReportMax: parseInt(
+			core.getInput("flaky-rate-report-max") || "10",
+			10,
+		),
+		failRateReportMax: parseInt(
+			core.getInput("fail-rate-report-max") || "10",
+			10,
+		),
 		metricsReportsMax: parseInt(
 			core.getInput("metrics-reports-max") || "100",
 			10,

--- a/src/ctrf/helpers.ts
+++ b/src/ctrf/helpers.ts
@@ -50,6 +50,72 @@ export function limitPreviousReports(
 }
 
 /**
+ * Limits the tests included in the flaky rate report to a specified maximum.
+ *
+ * @param report - The CTRF report to modify.
+ * @param maxFlakyTests - The maximum number of flaky tests to include.
+ * @returns The updated CTRF report with the limited flaky tests.
+ */
+export function limitFlakyRateReport(
+	report: CTRFReport,
+	maxFlakyTests: number,
+): CTRFReport {
+	if (!report.results?.tests || maxFlakyTests <= 0) {
+		return report;
+	}
+
+	const flakyTests = report.results.tests
+		.filter((test) => test.insights?.flakyRate?.current > 0)
+		.sort(
+			(a, b) =>
+				(b.insights?.flakyRate?.current ?? 0) -
+				(a.insights?.flakyRate?.current ?? 0),
+		)
+		.slice(0, maxFlakyTests);
+
+	return {
+		...report,
+		results: {
+			...report.results,
+			tests: flakyTests,
+		},
+	};
+}
+
+/**
+ * Limits the tests included in the fail rate report to a specified maximum.
+ *
+ * @param report - The CTRF report to modify.
+ * @param maxFailedTests - The maximum number of failed tests to include.
+ * @returns The updated CTRF report with the limited failed tests.
+ */
+export function limitFailRateReport(
+	report: CTRFReport,
+	maxFailedTests: number,
+): CTRFReport {
+	if (!report.results?.tests || maxFailedTests <= 0) {
+		return report;
+	}
+
+	const failedTests = report.results.tests
+		.filter((test) => test.insights?.failRate?.current > 0)
+		.sort(
+			(a, b) =>
+				(b.insights?.failRate?.current ?? 0) -
+				(a.insights?.failRate?.current ?? 0),
+		)
+		.slice(0, maxFailedTests);
+
+	return {
+		...report,
+		results: {
+			...report.results,
+			tests: failedTests,
+		},
+	};
+}
+
+/**
  * Retrieves an emoji representation for a given test state or category.
  *
  * @param status - The test state or category to get an emoji for.

--- a/src/github/core.ts
+++ b/src/github/core.ts
@@ -1,5 +1,11 @@
 import * as core from "@actions/core";
-import { limitPreviousReports, stripAnsi, getEmoji } from "../ctrf/index.js";
+import {
+	limitFailRateReport,
+	limitFlakyRateReport,
+	limitPreviousReports,
+	stripAnsi,
+	getEmoji,
+} from "../ctrf/index.js";
 import { generateMarkdown } from "../handlebars/core.js";
 import type {
 	Inputs,
@@ -278,7 +284,11 @@ function generateReportByType(
 		case "fail-rate-report":
 			if (reportConditionals?.showFailedReports) {
 				core.info("Adding fail rate report to summary");
-				addViewToSummary("### Fail Rate", BuiltInReports.FailRateTable, report);
+				addViewToSummary(
+					"### Fail Rate",
+					BuiltInReports.FailRateTable,
+					limitFailRateReport(report, inputs.failRateReportMax),
+				);
 			} else {
 				core.info("No failed tests to display, skipping fail-rate-report");
 			}
@@ -309,7 +319,7 @@ function generateReportByType(
 				addViewToSummary(
 					"### Flaky Rate",
 					BuiltInReports.FlakyRateTable,
-					report,
+					limitFlakyRateReport(report, inputs.flakyRateReportMax),
 				);
 			} else {
 				core.info("No flaky tests to display, skipping flaky-rate-report");

--- a/src/github/core.ts
+++ b/src/github/core.ts
@@ -285,7 +285,9 @@ function generateReportByType(
 			if (reportConditionals?.showFailedReports) {
 				core.info("Adding fail rate report to summary");
 				addViewToSummary(
-					"### Fail Rate",
+					inputs.failRateReportMax > 0
+						? `### Fail Rate - Top ${inputs.failRateReportMax} `
+						: "### Fail Rate",
 					BuiltInReports.FailRateTable,
 					limitFailRateReport(report, inputs.failRateReportMax),
 				);
@@ -317,7 +319,9 @@ function generateReportByType(
 			if (reportConditionals?.showFlakyReports) {
 				core.info("Adding flaky rate report to summary");
 				addViewToSummary(
-					"### Flaky Rate",
+					inputs.flakyRateReportMax > 0
+						? `### Flaky Rate - Top ${inputs.flakyRateReportMax} `
+						: "### Flaky Rate",
 					BuiltInReports.FlakyRateTable,
 					limitFlakyRateReport(report, inputs.flakyRateReportMax),
 				);

--- a/src/types/reporter.ts
+++ b/src/types/reporter.ts
@@ -42,6 +42,8 @@ export interface Inputs {
 	exitOnFail: boolean;
 	useSuiteName: boolean;
 	previousResultsMax: number;
+	flakyRateReportMax: number;
+	failRateReportMax: number;
 	metricsReportsMax: number;
 	maxWorkflowRunsToCheck: number;
 	maxPreviousRunsToFetch: number;


### PR DESCRIPTION
Introduce configurable limits for flaky and fail-rate reports so that large test suites do not have massive reports when there are bad runs.
Adds new inputs (flaky-rate-report-max, fail-rate-report-max) in action.yml and README.
Implements limitFlakyRateReport and limitFailRateReport (filter positive rates, sort desc, slice to max) and applies them when generating reports. 